### PR TITLE
Fix GitLab CI publish path

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,10 @@
 pages:
   stage: deploy
   script:
-    - mkdir .public
-    - cp -r * .public
+    - mkdir public
+    - cp -r * public
   artifacts:
     paths:
-      - .public
+      - public
   only:
     - main


### PR DESCRIPTION
## Summary
- use `public` directory instead of hidden `.public` in `.gitlab-ci.yml`
- update deployment copy command accordingly

## Testing
- `cat .gitlab-ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_685574404d4883298cb6d363c22a65b2