### PR TITLE
Update lang attribute when language switches

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,9 @@
     };
     let curLang = 'ru';
     function setLang(lang) {
+      lang = lang === 'kz' ? 'kz' : 'ru';
       curLang = lang;
+      document.documentElement.lang = lang;
       const l = langs[lang];
       document.getElementById('siteTitle').innerText = l.siteTitle;
       document.getElementById('slogan').innerHTML = l.slogan;


### PR DESCRIPTION
## Summary
- ensure the `lang` argument is valid
- set the `<html>` element's `lang` attribute in `setLang`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855746f564c832988043c1d096eaf4b