### PR TITLE
Add service form fields and messenger choice

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,11 @@
     <div class="modal">
       <span class="modal-close" onclick="closeModal()">&times;</span>
       <form onsubmit="sendForm(event)">
+        <div class="service-display"><span id="serviceLabel">Услуга:</span> <span id="serviceName"></span></div>
+        <input id="serviceInput" type="hidden">
         <input id="nameInput" type="text" placeholder="Ваше имя" required>
+        <input id="phoneInput" type="tel" placeholder="Телефон" required>
+        <input id="emailInput" type="email" placeholder="Email (необязательно)">
         <textarea id="questionInput" rows="3" placeholder="Ваш вопрос" required></textarea>
         <label id="messengerLabel" for="messengerSelect" class="messenger-label"></label>
           <select id="messengerSelect" class="messenger-select">

--- a/main.js
+++ b/main.js
@@ -34,6 +34,9 @@ const langs = {
         contactsTitle: "Контакты",
         phoneLabel: "Телефон (WhatsApp):",
         namePlaceholder: "Ваше имя",
+        phonePlaceholder: "Телефон",
+        emailPlaceholder: "Email (необязательно)",
+        serviceLabelText: "Услуга:",
         questionPlaceholder: "Ваш вопрос",
         messengerLabel: "Отправить через:",
         submitBtn: "Отправить",
@@ -78,6 +81,9 @@ const langs = {
         contactsTitle: "Байланыс",
         phoneLabel: "Телефон (WhatsApp):",
         namePlaceholder: "Атыңыз",
+        phonePlaceholder: "Телефон",
+        emailPlaceholder: "Email (міндетті емес)",
+        serviceLabelText: "Қызмет:",
         questionPlaceholder: "Сұрағыңыз",
         messengerLabel: "Қай мессенджер арқылы жіберу:",
         submitBtn: "Жіберу",
@@ -122,6 +128,9 @@ const langs = {
     contactsTitle: "Contacts",
     phoneLabel: "Phone (WhatsApp):",
     namePlaceholder: "Your name",
+    phonePlaceholder: "Phone",
+    emailPlaceholder: "Email (optional)",
+    serviceLabelText: "Service:",
     questionPlaceholder: "Your question",
     messengerLabel: "Send via:",
     submitBtn: "Send",
@@ -144,7 +153,7 @@ function setLang(lang) {
   document.querySelectorAll('#requestBtn, #requestBtn2').forEach(btn => btn && (btn.innerText = l.requestBtn));
   setElText('servicesTitle', l.servicesTitle);
   const servicesEl = document.getElementById('servicesList');
-  if(servicesEl) servicesEl.innerHTML = l.services.map(s=>`<li>${s}</li>`).join('');
+  if(servicesEl) servicesEl.innerHTML = l.services.map(s=>`<li>${s} <button class="service-btn" onclick="openModal('${s}')">${l.requestBtn}</button></li>`).join('');
   setElText('projectsTitle', l.projectsTitle);
   const projectsEl = document.getElementById('projectsList');
   if(projectsEl) projectsEl.innerHTML = l.projects.map(p=>`<li>${p}</li>`).join('');
@@ -156,7 +165,10 @@ function setLang(lang) {
   setElText('contactsTitle', l.contactsTitle);
   setElText('phoneLabel', l.phoneLabel);
   const nameInput=document.getElementById('nameInput'); if(nameInput) nameInput.placeholder = l.namePlaceholder;
+  const phoneInput=document.getElementById('phoneInput'); if(phoneInput) phoneInput.placeholder = l.phonePlaceholder;
+  const emailInput=document.getElementById('emailInput'); if(emailInput) emailInput.placeholder = l.emailPlaceholder;
   const qInput=document.getElementById('questionInput'); if(qInput) qInput.placeholder = l.questionPlaceholder;
+  const servLabel=document.getElementById('serviceLabel'); if(servLabel) servLabel.innerText = l.serviceLabelText;
   setElText('messengerLabel', l.messengerLabel);
   const submit=document.getElementById('submitBtn'); if(submit) submit.innerText = l.submitBtn;
   const langBtn=document.getElementById('langBtn'); if(langBtn) langBtn.innerText = l.langBtn;
@@ -179,10 +191,13 @@ if(qrCodeEl){
 }
 
     // Модалка
-    function openModal() {
+    function openModal(service) {
       document.getElementById('modalBg').style.display = 'flex';
       document.getElementById('formMsg').style.display = 'none';
-      document.querySelector('#modalBg form').reset();
+      const form = document.querySelector('#modalBg form');
+      form.reset();
+      document.getElementById('serviceName').innerText = service || '';
+      document.getElementById('serviceInput').value = service || '';
     }
     function closeModal() {
       document.getElementById('modalBg').style.display = 'none';
@@ -193,6 +208,9 @@ if(qrCodeEl){
     async function sendForm(e) {
       e.preventDefault();
       const name = document.getElementById('nameInput').value;
+      const phone = document.getElementById('phoneInput').value;
+      const email = document.getElementById('emailInput').value;
+      const service = document.getElementById('serviceInput').value;
       const question = document.getElementById('questionInput').value;
       const messenger = document.getElementById('messengerSelect').value;
       const msgEl = document.getElementById('formMsg');
@@ -201,7 +219,7 @@ if(qrCodeEl){
         const res = await fetch('/api/feedback', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name, question, messenger })
+          body: JSON.stringify({ name, phone, email, service, question, messenger })
         });
         if (!res.ok) throw new Error('fail');
         msgEl.style.color = '#37ff86';
@@ -211,7 +229,7 @@ if(qrCodeEl){
       }
       msgEl.innerText = langs[curLang].formSuccess;
 
-      const text = encodeURIComponent(`Имя: ${name}\nВопрос: ${question}`);
+      const text = encodeURIComponent(`Имя: ${name}\nТелефон: ${phone}\nEmail: ${email}\nУслуга: ${service}\nВопрос: ${question}`);
       let url = '';
       if (messenger === 'whatsapp') {
         url = `https://wa.me/77052546613?text=${text}`;

--- a/server.js
+++ b/server.js
@@ -21,9 +21,9 @@ app.use('/api/feedback', (req, res, next) => {
 });
 
 app.post('/api/feedback', async (req, res) => {
-  const { name, question, messenger } = req.body;
-  if (!name || !question) return res.status(400).json({error: 'missing'});
-  const text = `Имя: ${name}\nВопрос: ${question}\nМессенджер: ${messenger}`;
+  const { name, phone, email, service, question, messenger } = req.body;
+  if (!name || !phone || !question) return res.status(400).json({error: 'missing'});
+  const text = `Имя: ${name}\nТелефон: ${phone}\nEmail: ${email || ''}\nУслуга: ${service || ''}\nВопрос: ${question}\nМессенджер: ${messenger}`;
   try {
     const transporter = nodemailer.createTransport({ sendmail: true });
     await transporter.sendMail({

--- a/services.html
+++ b/services.html
@@ -147,7 +147,11 @@
     <div class="modal">
       <span class="modal-close" onclick="closeModal()">&times;</span>
       <form onsubmit="sendForm(event)">
+        <div class="service-display"><span id="serviceLabel">Услуга:</span> <span id="serviceName"></span></div>
+        <input id="serviceInput" type="hidden">
         <input id="nameInput" type="text" placeholder="Ваше имя" required>
+        <input id="phoneInput" type="tel" placeholder="Телефон" required>
+        <input id="emailInput" type="email" placeholder="Email (необязательно)">
         <textarea id="questionInput" rows="3" placeholder="Ваш вопрос" required></textarea>
         <label id="messengerLabel" for="messengerSelect" class="messenger-label"></label>
           <select id="messengerSelect" class="messenger-select">

--- a/styles.css
+++ b/styles.css
@@ -46,4 +46,6 @@ li{margin-bottom:8px;font-size:1.08rem;}
 .modal input,.modal textarea{width:100%;background:#222b34;border:1px solid #2ec2f9;border-radius:9px;padding:10px 11px;color:#fff;margin-bottom:11px;}
 .modal button[type=submit]{background:linear-gradient(90deg,#36aaff,#16c0f8);color:#fff;border:none;padding:10px 0;border-radius:9px;width:100%;font-size:1.04rem;font-weight:600;cursor:pointer;}
 .modal-close{position:absolute;top:14px;right:20px;font-size:1.5rem;cursor:pointer;color:#fff;}
+.service-display{margin-bottom:10px;color:#b2ebff;font-size:0.95rem;}
+.service-btn{margin-left:10px;background:linear-gradient(90deg,#36aaff,#16c0f8);color:#fff;border:none;border-radius:12px;padding:4px 12px;font-size:0.9rem;cursor:pointer;}
 @media(max-width:600px){.container{padding:3vw;} .logo{width:70px;} .site-title{font-size:1.33rem;} .hero-slogan{font-size:1.18rem;} .sections{gap:12px;} .section{padding:14px 9px;} .nav{display:none;}}


### PR DESCRIPTION
## Summary
- extend modal forms with phone, email and service fields
- support messenger choice for each service request
- style new service forms and buttons
- update translations and scripts to handle new fields
- send full request data to backend

## Testing
- `node -e "require('./server.js');"` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6856bfff60088329b856b6046283be00