### PR TITLE
Fix default route for landing page

### DIFF
--- a/server.js
+++ b/server.js
@@ -56,6 +56,11 @@ app.post('/api/feedback', async (req, res) => {
   }
 });
 
+// Serve main page explicitly to avoid README being shown by hosting platforms
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use((req, res) => {


### PR DESCRIPTION
## Summary
- ensure the server serves `index.html` at the root path

## Testing
- `node -e "require('./server.js')" 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685708175408832999909de4294a0695