### PR TITLE
Implement service pages, color themes and PWA

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "nodemailer": "^6.9.1",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "multer": "^1.4.5-lts.1"
   },
   "scripts": {
     "start": "node server.js"

--- a/public/faq.html
+++ b/public/faq.html
@@ -11,7 +11,8 @@
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ctext y='14' font-size='14'%3EA%3C/text%3E%3C/svg%3E">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="manifest" href="manifest.json">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 </head>
@@ -28,6 +29,7 @@
         <a href="faq.html" id="navFAQ">FAQ</a>
       </nav>
       <button class="theme-btn" id="themeToggle">☾</button>
+      <button class="color-btn" id="colorToggle">🎨</button>
       <button class="lang-btn" id="langBtn">Қазақша</button>
     </header>
 

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,8 @@
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ctext y='14' font-size='14'%3EA%3C/text%3E%3C/svg%3E">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="manifest" href="manifest.json">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
   <!-- Иконки соцсетей через CDN -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
@@ -48,6 +49,7 @@
           <a href="faq.html" id="navFAQ">FAQ</a>
         </nav>
         <button class="theme-btn" id="themeToggle">☾</button>
+        <button class="color-btn" id="colorToggle">🎨</button>
         <button class="lang-btn" id="langBtn">Қазақша</button>
       </header>
 
@@ -69,12 +71,12 @@
       <section class="section fade-in">
         <div class="section-title" id="servicesTitle">Наши услуги</div>
         <ul id="servicesList">
-          <li><i class="bi bi-lightning service-icon"></i> Разработка MVP (цифровых продуктов)</li>
-          <li><i class="bi bi-diagram-3 service-icon"></i> Интеграция сервисов (CRM, облако, чаты, API)</li>
-          <li><i class="bi bi-window service-icon"></i> Создание современных сайтов и лендингов</li>
-          <li><i class="bi bi-puzzle service-icon"></i> IT-консалтинг и аудит</li>
-          <li><i class="bi bi-gear service-icon"></i> Автоматизация бизнес-процессов</li>
-          <li><i class="bi bi-shield-lock service-icon"></i> Информбезопасность и защита данных</li>
+          <li><i class="bi bi-lightning service-icon"></i> <a href="services/mvp.html">Разработка MVP (цифровых продуктов)</a></li>
+          <li><i class="bi bi-diagram-3 service-icon"></i> <a href="services/integration.html">Интеграция сервисов (CRM, облако, чаты, API)</a></li>
+          <li><i class="bi bi-window service-icon"></i> <a href="services/websites.html">Создание современных сайтов и лендингов</a></li>
+          <li><i class="bi bi-puzzle service-icon"></i> <a href="services/consulting.html">IT-консалтинг и аудит</a></li>
+          <li><i class="bi bi-gear service-icon"></i> <a href="services/automation.html">Автоматизация бизнес-процессов</a></li>
+          <li><i class="bi bi-shield-lock service-icon"></i> <a href="services/security.html">Информбезопасность и защита данных</a></li>
         </ul>
       </section>
       <section class="section fade-in">
@@ -144,6 +146,15 @@
     <div id="calcResult"></div>
     <div class="calc-example" id="calcExample">(например: 10 ч × 5000 KZT/ч = 50000 KZT)</div>
   </section>
+  <section class="section fade-in" id="roiSection">
+    <div class="section-title" id="roiTitle">ROI калькулятор</div>
+    <div class="calc-row">
+      <input id="investInput" type="number" placeholder="Инвестиции" class="calc-input">
+      <input id="profitInput" type="number" placeholder="Доход" class="calc-input">
+      <button onclick="calcROI()" id="roiBtn" class="calc-btn">Рассчитать</button>
+    </div>
+    <div id="roiResult"></div>
+  </section>
 
   <section class="section privacy-section fade-in" id="privacy">
     Мы собираем имя, телефон, email (необязательно) и ответы на вопросы только для обратной связи. Информация не хранится на сайте и
@@ -162,7 +173,7 @@
   <div class="modal-bg" id="modalBg">
     <div class="modal">
       <span class="modal-close" onclick="closeModal()">&times;</span>
-      <form onsubmit="sendForm(event)">
+      <form onsubmit="sendForm(event)" enctype="multipart/form-data">
         <div class="service-display"><span id="serviceLabel">Услуга:</span> <span id="serviceName"></span></div>
         <input id="serviceInput" type="hidden">
         <div id="dynamicFields"></div>
@@ -170,6 +181,7 @@
         <input id="nameInput" type="text" placeholder="Ваше имя" required>
         <input id="phoneInput" type="tel" placeholder="Телефон" required>
         <input id="emailInput" type="email" placeholder="Email (необязательно)">
+        <input id="fileInput" type="file">
         <label id="messengerLabel" for="messengerSelect" class="messenger-label"></label>
         <select id="messengerSelect" class="messenger-select">
           <option value="whatsapp">WhatsApp</option>

--- a/public/main.js
+++ b/public/main.js
@@ -53,7 +53,10 @@ const langs = {
     calcTitle: "Калькулятор стоимости",
     calcBtn: "Рассчитать",
     calcExample: "(например: 10 ч × 5000 KZT/ч = 50000 KZT)",
-    calcResultText: "Итого: "
+    calcResultText: "Итого: ",
+    roiTitle: "ROI калькулятор",
+    roiBtn: "Рассчитать",
+    roiResultText: "ROI: "
   },
   kz: {
         siteTitle: "AliQ Group",
@@ -108,7 +111,10 @@ const langs = {
     calcTitle: "Құнының калькуляторы",
     calcBtn: "Есептеу",
     calcExample: "(мысалы: 10 сағ × 5000 KZT/сағ = 50000 KZT)",
-    calcResultText: "Жиынтығы: "
+    calcResultText: "Жиынтығы: ",
+    roiTitle: "ROI есептеуі",
+    roiBtn: "Есептеу",
+    roiResultText: "ROI: "
   },
   en: {
     siteTitle: "AliQ Group",
@@ -163,7 +169,10 @@ const langs = {
     calcTitle: "Cost calculator",
     calcBtn: "Calculate",
     calcExample: "(e.g.: 10 h × 5000 KZT/h = 50000 KZT)",
-    calcResultText: "Total: "
+    calcResultText: "Total: ",
+    roiTitle: "ROI calculator",
+    roiBtn: "Calculate",
+    roiResultText: "ROI: "
   }
 };
 // Вопросы по услугам
@@ -237,6 +246,8 @@ function setLang(lang) {
   setElText('calcTitle', l.calcTitle);
   const calcBtn=document.getElementById('calcBtn'); if(calcBtn) calcBtn.innerText = l.calcBtn;
   setElText('calcExample', l.calcExample);
+  setElText('roiTitle', l.roiTitle);
+  const roiBtn=document.getElementById('roiBtn'); if(roiBtn) roiBtn.innerText = l.roiBtn;
   setElText('formMsg', l.formSuccess);
   setElText('qrText', l.qrText);
 }
@@ -305,10 +316,18 @@ function openModal(service) {
       const msgEl = document.getElementById('formMsg');
       msgEl.style.display = 'block';
       try {
+        const fd = new FormData();
+        fd.append('name', name);
+        fd.append('phone', phone);
+        fd.append('email', email);
+        fd.append('service', service);
+        fd.append('question', question);
+        fd.append('messenger', messenger);
+        const fileEl = document.getElementById('fileInput');
+        if(fileEl && fileEl.files[0]) fd.append('file', fileEl.files[0]);
         const res = await fetch('/api/feedback', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name, phone, email, service, question, messenger })
+          body: fd
         });
         if (!res.ok) throw new Error('fail');
         msgEl.style.color = '#37ff86';
@@ -362,10 +381,39 @@ const observer = new IntersectionObserver(entries => {
     }
     applyTheme();
 
+    function applyColor(){
+      const col=localStorage.color||'blue';
+      const root=document.documentElement;
+      if(col==='green'){ root.style.setProperty('--accent1','#2af598'); root.style.setProperty('--accent2','#009eeb'); }
+      else if(col==='purple'){ root.style.setProperty('--accent1','#ff35a6'); root.style.setProperty('--accent2','#6e3bff'); }
+      else { root.style.setProperty('--accent1','#36aaff'); root.style.setProperty('--accent2','#16c0f8'); }
+    }
+    const colorBtn=document.getElementById('colorToggle');
+    if(colorBtn){
+      colorBtn.onclick=function(){
+        const cur=localStorage.color||'blue';
+        localStorage.color=cur==='blue'?'green':(cur==='green'?'purple':'blue');
+        applyColor();
+      };
+    }
+    applyColor();
+
+    if('serviceWorker' in navigator){
+      navigator.serviceWorker.register('service-worker.js');
+    }
+
     window.calcCost = function(){
       const h=parseFloat(document.getElementById('hoursInput').value)||0;
       const r=parseFloat(document.getElementById('rateInput').value)||0;
       const res=h*r;
       const out=document.getElementById('calcResult');
       out.innerText=res?langs[curLang].calcResultText+res+' KZT':'';
+    };
+
+    window.calcROI = function(){
+      const inv=parseFloat(document.getElementById('investInput').value)||0;
+      const prof=parseFloat(document.getElementById('profitInput').value)||0;
+      const roi=inv?((prof-inv)/inv*100).toFixed(1):0;
+      const out=document.getElementById('roiResult');
+      out.innerText=inv?langs[curLang].roiResultText+roi+'%':'';
     };

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "AliQ Group",
+  "short_name": "AliQ",
+  "start_url": "index.html",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#36aaff",
+  "icons": [
+    {
+      "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+P8/AAX+Av6Qs+MAAAAASUVORK5CYII=",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+P8/AAX+Av6Qs+MAAAAASUVORK5CYII=",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/schedule.html
+++ b/public/schedule.html
@@ -11,7 +11,8 @@
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ctext y='14' font-size='14'%3EA%3C/text%3E%3C/svg%3E">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="manifest" href="manifest.json">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 </head>
@@ -28,6 +29,7 @@
         <a href="faq.html" id="navFAQ">FAQ</a>
       </nav>
       <button class="theme-btn" id="themeToggle">☾</button>
+      <button class="color-btn" id="colorToggle">🎨</button>
       <button class="lang-btn" id="langBtn">Қазақша</button>
     </header>
 

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,18 @@
+const CACHE_NAME = 'aliq-cache-v1';
+const urls = [
+  '/',
+  '/index.html',
+  '/services.html',
+  '/schedule.html',
+  '/faq.html',
+  '/styles.css',
+  '/main.js'
+];
+self.addEventListener('install', e => {
+  e.waitUntil(caches.open(CACHE_NAME).then(c => c.addAll(urls)));
+});
+self.addEventListener('fetch', e => {
+  e.respondWith(
+    caches.match(e.request).then(r => r || fetch(e.request))
+  );
+});

--- a/public/services.html
+++ b/public/services.html
@@ -13,7 +13,8 @@
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ctext y='14' font-size='14'%3EA%3C/text%3E%3C/svg%3E">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="manifest" href="manifest.json">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
   <!-- Иконки соцсетей через CDN -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
@@ -48,6 +49,7 @@
           <a href="faq.html" id="navFAQ">FAQ</a>
         </nav>
         <button class="theme-btn" id="themeToggle">☾</button>
+        <button class="color-btn" id="colorToggle">🎨</button>
         <button class="lang-btn" id="langBtn">Қазақша</button>
       </header>
 
@@ -69,12 +71,12 @@
       <section class="section fade-in">
         <div class="section-title" id="servicesTitle">Наши услуги</div>
         <ul id="servicesList">
-          <li><i class="bi bi-lightning service-icon"></i> Разработка MVP (цифровых продуктов)</li>
-          <li><i class="bi bi-diagram-3 service-icon"></i> Интеграция сервисов (CRM, облако, чаты, API)</li>
-          <li><i class="bi bi-window service-icon"></i> Создание современных сайтов и лендингов</li>
-          <li><i class="bi bi-puzzle service-icon"></i> IT-консалтинг и аудит</li>
-          <li><i class="bi bi-gear service-icon"></i> Автоматизация бизнес-процессов</li>
-          <li><i class="bi bi-shield-lock service-icon"></i> Информбезопасность и защита данных</li>
+          <li><i class="bi bi-lightning service-icon"></i> <a href="services/mvp.html">Разработка MVP (цифровых продуктов)</a></li>
+          <li><i class="bi bi-diagram-3 service-icon"></i> <a href="services/integration.html">Интеграция сервисов (CRM, облако, чаты, API)</a></li>
+          <li><i class="bi bi-window service-icon"></i> <a href="services/websites.html">Создание современных сайтов и лендингов</a></li>
+          <li><i class="bi bi-puzzle service-icon"></i> <a href="services/consulting.html">IT-консалтинг и аудит</a></li>
+          <li><i class="bi bi-gear service-icon"></i> <a href="services/automation.html">Автоматизация бизнес-процессов</a></li>
+          <li><i class="bi bi-shield-lock service-icon"></i> <a href="services/security.html">Информбезопасность и защита данных</a></li>
         </ul>
       </section>
       <section class="section fade-in">
@@ -151,7 +153,7 @@
   <div class="modal-bg" id="modalBg">
     <div class="modal">
       <span class="modal-close" onclick="closeModal()">&times;</span>
-      <form onsubmit="sendForm(event)">
+      <form onsubmit="sendForm(event)" enctype="multipart/form-data">
         <div class="service-display"><span id="serviceLabel">Услуга:</span> <span id="serviceName"></span></div>
         <input id="serviceInput" type="hidden">
         <div id="dynamicFields"></div>
@@ -159,6 +161,7 @@
         <input id="nameInput" type="text" placeholder="Ваше имя" required>
         <input id="phoneInput" type="tel" placeholder="Телефон" required>
         <input id="emailInput" type="email" placeholder="Email (необязательно)">
+        <input id="fileInput" type="file">
         <label id="messengerLabel" for="messengerSelect" class="messenger-label"></label>
         <select id="messengerSelect" class="messenger-select">
           <option value="whatsapp">WhatsApp</option>

--- a/public/services/automation.html
+++ b/public/services/automation.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>Автоматизация процессов — AliQ Group</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="../manifest.json">
+  <link rel="stylesheet" href="../styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+</head>
+<body>
+<div class="container">
+  <header class="header">
+    <div class="header-flex">
+      <span class="site-title" id="siteTitle">AliQ Group</span>
+    </div>
+    <nav class="nav">
+      <a href="../index.html" id="navHome">Главная</a>
+      <a href="../services.html" id="navServices">Услуги</a>
+      <a href="../schedule.html" id="navSchedule">Встреча</a>
+      <a href="../faq.html" id="navFAQ">FAQ</a>
+    </nav>
+    <button class="theme-btn" id="themeToggle">☾</button>
+    <button class="color-btn" id="colorToggle">🎨</button>
+    <button class="lang-btn" id="langBtn">Қазақша</button>
+  </header>
+  <main>
+    <section class="section fade-in">
+      <div class="section-title">Автоматизация бизнес‑процессов</div>
+      <p>Ускоряем операции компании за счёт внедрения скриптов и интеграций.</p>
+      <p>Настраиваем отчётность, уведомления и другие инструменты для роста эффективности.</p>
+    </section>
+    <div class="bottom-action" style="text-align:center">
+      <a href="#" onclick="openModal('Автоматизация бизнес-процессов');return false;" class="hero-action" id="requestBtn">Оставить заявку</a>
+    </div>
+  </main>
+  <footer class="footer">
+    © <span id="year3"></span> AliQ Group
+  </footer>
+</div>
+<div class="modal-bg" id="modalBg">
+  <div class="modal">
+    <span class="modal-close" onclick="closeModal()">&times;</span>
+    <form onsubmit="sendForm(event)" enctype="multipart/form-data">
+      <div class="service-display"><span id="serviceLabel">Услуга:</span> <span id="serviceName"></span></div>
+      <input id="serviceInput" type="hidden">
+      <div id="dynamicFields"></div>
+      <textarea id="questionInput" rows="3" placeholder="Ваш вопрос" required></textarea>
+      <input id="nameInput" type="text" placeholder="Ваше имя" required>
+      <input id="phoneInput" type="tel" placeholder="Телефон" required>
+      <input id="emailInput" type="email" placeholder="Email (необязательно)">
+      <input id="fileInput" type="file">
+      <label id="messengerLabel" for="messengerSelect" class="messenger-label"></label>
+      <select id="messengerSelect" class="messenger-select">
+        <option value="whatsapp">WhatsApp</option>
+        <option value="telegram">Telegram</option>
+      </select>
+      <button type="submit" id="submitBtn">Отправить</button>
+      <div id="formMsg" class="form-msg"></div>
+    </form>
+  </div>
+</div>
+<script src="../main.js"></script>
+<script src="../config.js"></script>
+</body>
+</html>

--- a/public/services/consulting.html
+++ b/public/services/consulting.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>IT‑консалтинг и аудит — AliQ Group</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="../manifest.json">
+  <link rel="stylesheet" href="../styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+</head>
+<body>
+<div class="container">
+  <header class="header">
+    <div class="header-flex">
+      <span class="site-title" id="siteTitle">AliQ Group</span>
+    </div>
+    <nav class="nav">
+      <a href="../index.html" id="navHome">Главная</a>
+      <a href="../services.html" id="navServices">Услуги</a>
+      <a href="../schedule.html" id="navSchedule">Встреча</a>
+      <a href="../faq.html" id="navFAQ">FAQ</a>
+    </nav>
+    <button class="theme-btn" id="themeToggle">☾</button>
+    <button class="color-btn" id="colorToggle">🎨</button>
+    <button class="lang-btn" id="langBtn">Қазақша</button>
+  </header>
+  <main>
+    <section class="section fade-in">
+      <div class="section-title">IT‑консалтинг и аудит</div>
+      <p>Анализируем инфраструктуру и процессы вашей компании.</p>
+      <p>Предлагаем улучшения, помогаем подготовиться к сертификациям и оптимизировать издержки.</p>
+    </section>
+    <div class="bottom-action" style="text-align:center">
+      <a href="#" onclick="openModal('IT-консалтинг');return false;" class="hero-action" id="requestBtn">Оставить заявку</a>
+    </div>
+  </main>
+  <footer class="footer">
+    © <span id="year3"></span> AliQ Group
+  </footer>
+</div>
+<div class="modal-bg" id="modalBg">
+  <div class="modal">
+    <span class="modal-close" onclick="closeModal()">&times;</span>
+    <form onsubmit="sendForm(event)" enctype="multipart/form-data">
+      <div class="service-display"><span id="serviceLabel">Услуга:</span> <span id="serviceName"></span></div>
+      <input id="serviceInput" type="hidden">
+      <div id="dynamicFields"></div>
+      <textarea id="questionInput" rows="3" placeholder="Ваш вопрос" required></textarea>
+      <input id="nameInput" type="text" placeholder="Ваше имя" required>
+      <input id="phoneInput" type="tel" placeholder="Телефон" required>
+      <input id="emailInput" type="email" placeholder="Email (необязательно)">
+      <input id="fileInput" type="file">
+      <label id="messengerLabel" for="messengerSelect" class="messenger-label"></label>
+      <select id="messengerSelect" class="messenger-select">
+        <option value="whatsapp">WhatsApp</option>
+        <option value="telegram">Telegram</option>
+      </select>
+      <button type="submit" id="submitBtn">Отправить</button>
+      <div id="formMsg" class="form-msg"></div>
+    </form>
+  </div>
+</div>
+<script src="../main.js"></script>
+<script src="../config.js"></script>
+</body>
+</html>

--- a/public/services/integration.html
+++ b/public/services/integration.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>Интеграция сервисов — AliQ Group</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="../manifest.json">
+  <link rel="stylesheet" href="../styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+</head>
+<body>
+<div class="container">
+  <header class="header">
+    <div class="header-flex">
+      <span class="site-title" id="siteTitle">AliQ Group</span>
+    </div>
+    <nav class="nav">
+      <a href="../index.html" id="navHome">Главная</a>
+      <a href="../services.html" id="navServices">Услуги</a>
+      <a href="../schedule.html" id="navSchedule">Встреча</a>
+      <a href="../faq.html" id="navFAQ">FAQ</a>
+    </nav>
+    <button class="theme-btn" id="themeToggle">☾</button>
+    <button class="color-btn" id="colorToggle">🎨</button>
+    <button class="lang-btn" id="langBtn">Қазақша</button>
+  </header>
+  <main>
+    <section class="section fade-in">
+      <div class="section-title">Интеграция сервисов</div>
+      <p>Соединяем ваши системы, CRM и облачные сервисы в единую экосистему.</p>
+      <p>Автоматизируем обмен данными и настраиваем API для устойчивой работы.</p>
+    </section>
+    <div class="bottom-action" style="text-align:center">
+      <a href="#" onclick="openModal('Интеграция сервисов');return false;" class="hero-action" id="requestBtn">Оставить заявку</a>
+    </div>
+  </main>
+  <footer class="footer">
+    © <span id="year3"></span> AliQ Group
+  </footer>
+</div>
+<div class="modal-bg" id="modalBg">
+  <div class="modal">
+    <span class="modal-close" onclick="closeModal()">&times;</span>
+    <form onsubmit="sendForm(event)" enctype="multipart/form-data">
+      <div class="service-display"><span id="serviceLabel">Услуга:</span> <span id="serviceName"></span></div>
+      <input id="serviceInput" type="hidden">
+      <div id="dynamicFields"></div>
+      <textarea id="questionInput" rows="3" placeholder="Ваш вопрос" required></textarea>
+      <input id="nameInput" type="text" placeholder="Ваше имя" required>
+      <input id="phoneInput" type="tel" placeholder="Телефон" required>
+      <input id="emailInput" type="email" placeholder="Email (необязательно)">
+      <input id="fileInput" type="file">
+      <label id="messengerLabel" for="messengerSelect" class="messenger-label"></label>
+      <select id="messengerSelect" class="messenger-select">
+        <option value="whatsapp">WhatsApp</option>
+        <option value="telegram">Telegram</option>
+      </select>
+      <button type="submit" id="submitBtn">Отправить</button>
+      <div id="formMsg" class="form-msg"></div>
+    </form>
+  </div>
+</div>
+<script src="../main.js"></script>
+<script src="../config.js"></script>
+</body>
+</html>

--- a/public/services/mvp.html
+++ b/public/services/mvp.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>MVP разработка — AliQ Group</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="../manifest.json">
+  <link rel="stylesheet" href="../styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+</head>
+<body>
+<div class="container">
+  <header class="header">
+    <div class="header-flex">
+      <span class="site-title" id="siteTitle">AliQ Group</span>
+    </div>
+    <nav class="nav">
+      <a href="../index.html" id="navHome">Главная</a>
+      <a href="../services.html" id="navServices">Услуги</a>
+      <a href="../schedule.html" id="navSchedule">Встреча</a>
+      <a href="../faq.html" id="navFAQ">FAQ</a>
+    </nav>
+    <button class="theme-btn" id="themeToggle">☾</button>
+    <button class="color-btn" id="colorToggle">🎨</button>
+    <button class="lang-btn" id="langBtn">Қазақша</button>
+  </header>
+  <main>
+    <section class="section fade-in">
+      <div class="section-title">MVP разработка</div>
+      <p>Создаём минимально жизнеспособные продукты для проверки гипотез и быстрого выхода на рынок.</p>
+      <p>Помогаем определить ключевые функции и запускаем проект в сжатые сроки.</p>
+    </section>
+    <div class="bottom-action" style="text-align:center">
+      <a href="#" onclick="openModal('MVP разработка');return false;" class="hero-action" id="requestBtn">Оставить заявку</a>
+    </div>
+  </main>
+  <footer class="footer">
+    © <span id="year3"></span> AliQ Group
+  </footer>
+</div>
+<div class="modal-bg" id="modalBg">
+  <div class="modal">
+    <span class="modal-close" onclick="closeModal()">&times;</span>
+    <form onsubmit="sendForm(event)" enctype="multipart/form-data">
+      <div class="service-display"><span id="serviceLabel">Услуга:</span> <span id="serviceName"></span></div>
+      <input id="serviceInput" type="hidden">
+      <div id="dynamicFields"></div>
+      <textarea id="questionInput" rows="3" placeholder="Ваш вопрос" required></textarea>
+      <input id="nameInput" type="text" placeholder="Ваше имя" required>
+      <input id="phoneInput" type="tel" placeholder="Телефон" required>
+      <input id="emailInput" type="email" placeholder="Email (необязательно)">
+      <input id="fileInput" type="file">
+      <label id="messengerLabel" for="messengerSelect" class="messenger-label"></label>
+      <select id="messengerSelect" class="messenger-select">
+        <option value="whatsapp">WhatsApp</option>
+        <option value="telegram">Telegram</option>
+      </select>
+      <button type="submit" id="submitBtn">Отправить</button>
+      <div id="formMsg" class="form-msg"></div>
+    </form>
+  </div>
+</div>
+<script src="../main.js"></script>
+<script src="../config.js"></script>
+</body>
+</html>

--- a/public/services/security.html
+++ b/public/services/security.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>Информационная безопасность — AliQ Group</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="../manifest.json">
+  <link rel="stylesheet" href="../styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+</head>
+<body>
+<div class="container">
+  <header class="header">
+    <div class="header-flex">
+      <span class="site-title" id="siteTitle">AliQ Group</span>
+    </div>
+    <nav class="nav">
+      <a href="../index.html" id="navHome">Главная</a>
+      <a href="../services.html" id="navServices">Услуги</a>
+      <a href="../schedule.html" id="navSchedule">Встреча</a>
+      <a href="../faq.html" id="navFAQ">FAQ</a>
+    </nav>
+    <button class="theme-btn" id="themeToggle">☾</button>
+    <button class="color-btn" id="colorToggle">🎨</button>
+    <button class="lang-btn" id="langBtn">Қазақша</button>
+  </header>
+  <main>
+    <section class="section fade-in">
+      <div class="section-title">Информационная безопасность</div>
+      <p>Проводим анализ рисков и реализуем комплексную защиту данных.</p>
+      <p>Настраиваем политики безопасности, системы мониторинга и реагирования на угрозы.</p>
+    </section>
+    <div class="bottom-action" style="text-align:center">
+      <a href="#" onclick="openModal('Информбезопасность');return false;" class="hero-action" id="requestBtn">Оставить заявку</a>
+    </div>
+  </main>
+  <footer class="footer">
+    © <span id="year3"></span> AliQ Group
+  </footer>
+</div>
+<div class="modal-bg" id="modalBg">
+  <div class="modal">
+    <span class="modal-close" onclick="closeModal()">&times;</span>
+    <form onsubmit="sendForm(event)" enctype="multipart/form-data">
+      <div class="service-display"><span id="serviceLabel">Услуга:</span> <span id="serviceName"></span></div>
+      <input id="serviceInput" type="hidden">
+      <div id="dynamicFields"></div>
+      <textarea id="questionInput" rows="3" placeholder="Ваш вопрос" required></textarea>
+      <input id="nameInput" type="text" placeholder="Ваше имя" required>
+      <input id="phoneInput" type="tel" placeholder="Телефон" required>
+      <input id="emailInput" type="email" placeholder="Email (необязательно)">
+      <input id="fileInput" type="file">
+      <label id="messengerLabel" for="messengerSelect" class="messenger-label"></label>
+      <select id="messengerSelect" class="messenger-select">
+        <option value="whatsapp">WhatsApp</option>
+        <option value="telegram">Telegram</option>
+      </select>
+      <button type="submit" id="submitBtn">Отправить</button>
+      <div id="formMsg" class="form-msg"></div>
+    </form>
+  </div>
+</div>
+<script src="../main.js"></script>
+<script src="../config.js"></script>
+</body>
+</html>

--- a/public/services/websites.html
+++ b/public/services/websites.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>Создание сайтов — AliQ Group</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="../manifest.json">
+  <link rel="stylesheet" href="../styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;500&family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+</head>
+<body>
+<div class="container">
+  <header class="header">
+    <div class="header-flex">
+      <span class="site-title" id="siteTitle">AliQ Group</span>
+    </div>
+    <nav class="nav">
+      <a href="../index.html" id="navHome">Главная</a>
+      <a href="../services.html" id="navServices">Услуги</a>
+      <a href="../schedule.html" id="navSchedule">Встреча</a>
+      <a href="../faq.html" id="navFAQ">FAQ</a>
+    </nav>
+    <button class="theme-btn" id="themeToggle">☾</button>
+    <button class="color-btn" id="colorToggle">🎨</button>
+    <button class="lang-btn" id="langBtn">Қазақша</button>
+  </header>
+  <main>
+    <section class="section fade-in">
+      <div class="section-title">Создание современных сайтов</div>
+      <p>Проектируем адаптивные и быстрые веб‑ресурсы, ориентированные на клиентов.</p>
+      <p>Используем актуальные технологии и обеспечиваем удобную админ‑панель.</p>
+    </section>
+    <div class="bottom-action" style="text-align:center">
+      <a href="#" onclick="openModal('Создание сайтов');return false;" class="hero-action" id="requestBtn">Оставить заявку</a>
+    </div>
+  </main>
+  <footer class="footer">
+    © <span id="year3"></span> AliQ Group
+  </footer>
+</div>
+<div class="modal-bg" id="modalBg">
+  <div class="modal">
+    <span class="modal-close" onclick="closeModal()">&times;</span>
+    <form onsubmit="sendForm(event)" enctype="multipart/form-data">
+      <div class="service-display"><span id="serviceLabel">Услуга:</span> <span id="serviceName"></span></div>
+      <input id="serviceInput" type="hidden">
+      <div id="dynamicFields"></div>
+      <textarea id="questionInput" rows="3" placeholder="Ваш вопрос" required></textarea>
+      <input id="nameInput" type="text" placeholder="Ваше имя" required>
+      <input id="phoneInput" type="tel" placeholder="Телефон" required>
+      <input id="emailInput" type="email" placeholder="Email (необязательно)">
+      <input id="fileInput" type="file">
+      <label id="messengerLabel" for="messengerSelect" class="messenger-label"></label>
+      <select id="messengerSelect" class="messenger-select">
+        <option value="whatsapp">WhatsApp</option>
+        <option value="telegram">Telegram</option>
+      </select>
+      <button type="submit" id="submitBtn">Отправить</button>
+      <div id="formMsg" class="form-msg"></div>
+    </form>
+  </div>
+</div>
+<script src="../main.js"></script>
+<script src="../config.js"></script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,17 +1,22 @@
+:root{
+  --accent1:#36aaff;
+  --accent2:#16c0f8;
+}
 @keyframes gradient-bg{0%{background-position:0 50%;}50%{background-position:100% 50%;}100%{background-position:0 50%;}}
 @keyframes gradient-text{0%{background-position:0 50%;}50%{background-position:100% 50%;}100%{background-position:0 50%;}}
-html,body{margin:0;padding:0;background:linear-gradient(135deg,#360033,#0b8793,#2af598);background-size:200% 200%;animation:gradient-bg 30s ease infinite;color:#f4f4f4;font-family:'Roboto',Arial,sans-serif;}
-a{color:#1ec7f8;text-decoration:none;}
+html,body{margin:0;padding:0;background:linear-gradient(135deg,#360033,#0b8793,#2af598);background-size:200% 200%;animation:gradient-bg 30s ease infinite;color:#f4f4f4;font-family:'Roboto','Montserrat',Arial,sans-serif;}
+a{color:var(--accent1);text-decoration:none;}
 a:hover{text-decoration:underline;}
 .container{max-width:900px;margin:0 auto;padding:32px;}
 .header{display:flex;align-items:center;justify-content:space-between;}
-.site-title{font-size:2.1rem;font-weight:700;color:#1ec7f8;letter-spacing:1px;font-family:'Poppins',sans-serif;}
+.site-title{font-size:2.1rem;font-weight:700;color:var(--accent1);letter-spacing:1px;font-family:'Poppins',sans-serif;}
 .nav{margin-left:20px;}
 .nav a{margin:0 10px;color:#b2ebff;font-size:1rem;}
 .nav a:hover{text-decoration:underline;}
-.lang-btn{background:linear-gradient(90deg,#36aaff,#16c0f8);color:#fff;border:none;border-radius:18px;padding:7px 20px;font-size:15px;cursor:pointer;}
+.lang-btn{background:linear-gradient(90deg,var(--accent1),var(--accent2));color:#fff;border:none;border-radius:18px;padding:7px 20px;font-size:15px;cursor:pointer;}
 .hero{margin:54px 0 36px 0;text-align:center;}
-.hero-slogan{font-size:2.2rem;line-height:1.22;font-weight:700;margin-bottom:15px;font-family:'Poppins',sans-serif;background:linear-gradient(90deg,#ff35a6,#5663ff,#00c2ff);background-size:200% 200%;-webkit-background-clip:text;color:transparent;animation:gradient-text 6s ease infinite;}
+.hero-slogan{font-size:2.2rem;line-height:1.22;font-weight:700;margin-bottom:15px;font-family:'Poppins',sans-serif;background:linear-gradient(90deg,#ff35a6,#5663ff,#00c2ff);background-size:200% 200%;-webkit-background-clip:text;color:transparent;animation:gradient-text 6s ease infinite;transition:transform .3s;}
+.hero-slogan:hover{transform:scale(1.05);}
 .hero-desc{font-size:1.18rem;color:#b2ebff;margin-bottom:12px;font-family:'Roboto',sans-serif;}
 .hero-action a{display:inline-block;background:linear-gradient(90deg,#ff512f,#dd2476);color:#fff;font-weight:500;padding:12px 34px;border-radius:16px;margin-top:18px;box-shadow:0 4px 16px #ff2fb0;transition:transform .2s;}
 .hero-action a:hover{transform:scale(1.05);}
@@ -46,14 +51,15 @@ li{margin-bottom:8px;font-size:1.08rem;}
 .modal-bg{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#0007;display:none;align-items:center;justify-content:center;z-index:1000;}
 .modal{background:#181e23;padding:28px 24px 18px 24px;border-radius:17px;max-width:340px;width:94vw;box-shadow:0 8px 40px #009ee97f;}
 .modal input,.modal textarea{width:100%;background:#222b34;border:1px solid #2ec2f9;border-radius:9px;padding:10px 11px;color:#fff;margin-bottom:11px;}
-.modal button[type=submit]{background:linear-gradient(90deg,#36aaff,#16c0f8);color:#fff;border:none;padding:10px 0;border-radius:9px;width:100%;font-size:1.04rem;font-weight:600;cursor:pointer;}
+.modal button[type=submit]{background:linear-gradient(90deg,var(--accent1),var(--accent2));color:#fff;border:none;padding:10px 0;border-radius:9px;width:100%;font-size:1.04rem;font-weight:600;cursor:pointer;}
 .modal-close{position:absolute;top:14px;right:20px;font-size:1.5rem;cursor:pointer;color:#fff;}
 .service-display{margin-bottom:10px;color:#b2ebff;font-size:0.95rem;}
 .service-btn{margin-left:10px;background:linear-gradient(90deg,#ff512f,#dd2476);color:#fff;border:none;border-radius:12px;padding:4px 12px;font-size:0.9rem;cursor:pointer;width:150px;text-align:center;transition:transform .2s;}
 .service-btn:hover{transform:scale(1.05);}
 .service-item{display:flex;justify-content:space-between;align-items:center;list-style:none;margin-bottom:8px;}
 #servicesList{padding-left:0;}
-.service-icon{margin-right:6px;color:#ff6bd6;font-size:1.1rem;vertical-align:middle;}
+.service-icon{margin-right:6px;color:#ff6bd6;font-size:1.1rem;vertical-align:middle;transition:transform .3s;}
+.service-item:hover .service-icon{transform:rotate(360deg);}
 .fade-in{opacity:0;transform:translateY(20px);transition:opacity .6s ease,transform .6s ease;}
 .fade-in.visible{opacity:1;transform:none;}
 @media(max-width:600px){.container{padding:3vw;} .site-title{font-size:1.33rem;} .hero-slogan{font-size:1.18rem;} .sections{gap:12px;} .section{padding:14px 9px;} .nav{display:none;}}
@@ -61,6 +67,8 @@ li{margin-bottom:8px;font-size:1.08rem;}
 /* Переключатель темы */
 .theme-btn{background:linear-gradient(90deg,#00c6ff,#0072ff);border:none;color:#fff;border-radius:18px;padding:6px 12px;margin-right:10px;cursor:pointer;transition:transform .2s;}
 .theme-btn:hover{transform:scale(1.1);}
+.color-btn{background:linear-gradient(90deg,var(--accent1),var(--accent2));border:none;color:#fff;border-radius:18px;padding:6px 12px;margin-right:10px;cursor:pointer;transition:transform .2s;}
+.color-btn:hover{transform:scale(1.1);}
 body.light{background:#fdfdfd;color:#222;}
 body.light .section{background:#f3f3f3;color:#222;}
 body.light a{color:#0077cc;}
@@ -69,7 +77,7 @@ body.light .footer{color:#555;}
 /* Калькулятор */
 .calc-row{display:flex;gap:10px;margin-bottom:10px;flex-wrap:wrap;}
 .calc-input{flex:1;background:#222b34;border:1px solid #2ec2f9;border-radius:9px;padding:10px 11px;color:#fff;min-width:120px;}
-.calc-btn{background:linear-gradient(90deg,#36aaff,#16c0f8);color:#fff;border:none;border-radius:9px;padding:10px 20px;cursor:pointer;}
+.calc-btn{background:linear-gradient(90deg,var(--accent1),var(--accent2));color:#fff;border:none;border-radius:9px;padding:10px 20px;cursor:pointer;}
 #calcResult{margin-top:5px;color:#b2ebff;}
 
 /* Калькулятор пример */

--- a/server.js
+++ b/server.js
@@ -1,8 +1,10 @@
 const path = require('path');
 const express = require('express');
 const nodemailer = require('nodemailer');
+const multer = require('multer');
 const cors = require('cors');
 const app = express();
+const upload = multer();
 app.use(express.json());
 app.use(cors());
 
@@ -37,8 +39,9 @@ app.get('/config.js', (req, res) => {
   res.type('application/javascript').send(`window.TAWK_ID=${JSON.stringify(TAWK_ID)};`);
 });
 
-app.post('/api/feedback', async (req, res) => {
+app.post('/api/feedback', upload.single('file'), async (req, res) => {
   const { name, phone, email, service, question, messenger } = req.body;
+  const file = req.file;
   if (!name || !phone || !question) return res.status(400).json({error: 'missing'});
   const text = `Имя: ${name}\nТелефон: ${phone}\nEmail: ${email || ''}\nУслуга: ${service || ''}\nВопрос: ${question}\nМессенджер: ${messenger}`;
   try {
@@ -47,7 +50,8 @@ app.post('/api/feedback', async (req, res) => {
       from: EMAIL_FROM,
       to: EMAIL_TO,
       subject: 'Заявка с сайта',
-      text
+      text,
+      attachments: file ? [{ filename: file.originalname, content: file.buffer }] : []
     });
     res.json({ success: true });
   } catch (e) {


### PR DESCRIPTION
## Summary
- add detailed service pages
- implement accent color themes and new Montserrat font
- register service worker and create manifest for PWA
- enable file attachments in feedback form
- add ROI calculator widget
- remove binary icons by embedding base64 images in the manifest

## Testing
- `node --check server.js`
- `npm start` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68582863ca08832995bc7b36e8c968ce