### PR TITLE
Configure mobile URL via env or app.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,11 @@ npm install
 npm start            # запустит Expo
 ```
 
-Expo позволит собрать приложение для Android и iOS. URL сайта задаётся в `App.js`.
+Expo позволит собрать приложение для Android и iOS. URL веб-версии можно задать 
+переменной окружения `SITE_URL` при запуске Expo:
+
+```bash
+SITE_URL=https://example.com npm start
+```
+
+Если переменная не указана, используется значение `siteUrl` в `mobile/app.json`.

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,13 +1,19 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
+import Constants from 'expo-constants';
 
 export default function App() {
+  const siteUrl =
+    process.env.SITE_URL ||
+    Constants.expoConfig?.extra?.siteUrl ||
+    'https://alibek0301.github.io/Aliqgroup/';
+
   return (
     <View style={styles.container}>
       <WebView
         originWhitelist={['*']}
-        source={{ uri: 'https://alibek0301.github.io/Aliqgroup/' }}
+        source={{ uri: siteUrl }}
         style={styles.webview}
       />
     </View>

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -22,6 +22,7 @@
       "package": "com.aliqgroup.app"
     },
     "extra": {
+      "siteUrl": "https://alibek0301.github.io/Aliqgroup/",
       "eas": {
         "projectId": "f86c2610-d035-48af-9673-09a2513f2990"
       }


### PR DESCRIPTION
## Summary
- read mobile URL from `process.env.SITE_URL` or `app.json`
- document how to set the Expo URL

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a43193b4c8329bd42e83b362bfba7