### PR TITLE
Fix mail links in mobile WebView

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Linking } from 'react-native';
 import { WebView } from 'react-native-webview';
 import Constants from 'expo-constants';
 
@@ -9,12 +9,22 @@ export default function App() {
     Constants.expoConfig?.extra?.siteUrl ||
     'https://alibek0301.github.io/Aliqgroup/';
 
+  const handleNavigation = (event) => {
+    const url = event.url || '';
+    if (url.startsWith('mailto:') || url.startsWith('tel:')) {
+      Linking.openURL(url).catch(() => {});
+      return false;
+    }
+    return true;
+  };
+
   return (
     <View style={styles.container}>
       <WebView
         originWhitelist={['*']}
         source={{ uri: siteUrl }}
         style={styles.webview}
+        onShouldStartLoadWithRequest={handleNavigation}
       />
     </View>
   );


### PR DESCRIPTION
## Summary
- intercept `mailto:`/`tel:` links in the mobile WebView and open them with the device

## Testing
- `npm test` (fails: Missing script)
- `cd mobile && npm test` (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_685a45492ffc8329bad5bfa79499ba42